### PR TITLE
Es3649/enh/v0.1.1

### DIFF
--- a/internal/cmd/info.go
+++ b/internal/cmd/info.go
@@ -51,7 +51,7 @@ Numbers         num     Acts            acts
 Joshua          jos     Romans          rom    
 Judges          judg    1 Corinthians   1-cor  
 Ruth            ruth    2 Corinthians   2-cor  
-1 Samuel        1-sam   Galations       gal    
+1 Samuel        1-sam   Galatians       gal    
 2 Samuel        2-sam   Ephesians       eph    
 1 Kings         1-kin   Philippians     philip 
 2 Kings         2-kin   Colossians      col    
@@ -92,7 +92,7 @@ JS-History      js-h    DOCTRINE AND    [dc]
 Articles        a-of-f    COVENANTS            
   of Faith              Sections        dc     
 
-NON-VERSE CONTENT:--Not Yet Impelemented
+NON-VERSE CONTENT:--Not Yet Implemented
                   BIBLE                        
 Epistle Dedicatory                      dedication
               BOOK OF MORMON                   
@@ -104,6 +104,15 @@ Testimony of the Eight Witnesses        eight
 Testimony of the ProphetJoseph Smith    js
 A Brief Explanation of the BofM         explanation
          DOCTRINE AND COVENANTS                
-Official Declarations                   od`)
+Official Declarations                   od
+
+LANGUAGE OPTIONS
+Libraries must be downloaded for each language,
+and downloading is currently only supported for English
+
+Language    Code
+English     eng
+Spanish     spa
+Portuguese  por`)
 	},
 }

--- a/internal/cmd/info.go
+++ b/internal/cmd/info.go
@@ -42,7 +42,7 @@ Verse Numbers:
     equivalent to John 17
 
 All Scripture (non-verse content excluded)  *  
-OLD TESTAMENT   [OT]    NEW TESTAMENT   [NT]   
+OLD TESTAMENT   [ot]    NEW TESTAMENT   [nt]   
 Genesis         gen     Matthew         matt   
 Exodous         ex      Mark            mark   
 Leviticus       lev     Luke            luke   
@@ -71,7 +71,7 @@ Lamentations    lam     3 John          3-jn
 Ezekiel         ezek    Jude            jude   
 Daniel          dan     Revelation      rev    
 Hosea           hosea                          
-Joel            joel    BOOK OF MORMON  [BOM]  
+Joel            joel    BOOK OF MORMON  [bom]  
 Amos            amos    1 Nephi         1-ne   
 Obadiah         obad    2 Nephi         2-ne   
 Jonah           jonah   Jacob           jacob  
@@ -83,12 +83,12 @@ Haggai          hag     Mosiah          mosiah
 Zechariah       zech    Alma            alma   
 Malachi         mal     Helaman         hel    
                         3 Nephi         3-ne   
-PEARL OF        [PGP]   4 Nephi         4-ne   
+PEARL OF        [pgp]   4 Nephi         4-ne   
   GREAT PRICE           Mormon          morm   
 Moses           moses   Ether           ether  
 Abraham         abr     Moroni          moro   
 JS-Matthew      js-m                           
-JS-History      js-h    DOCTRINE AND    [DC]   
+JS-History      js-h    DOCTRINE AND    [dc]   
 Articles        a-of-f    COVENANTS            
   of Faith              Sections        dc     
 

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -26,7 +26,7 @@ var rootCmd = &cobra.Command{
 The scriptures used in these libraries are owned by Intellectual Reserve Inc. And are available for free at https://lds.org/scriptures.
 The Church of Jesus Christ of Latter-day Saints is not affiliated with, nor endorses this project.
 
-Use 'scripturetool help' for explanation of arguments and abbreviations`,
+Use 'scripturetool info' for explanation of arguments and abbreviations`,
 	Args: cobra.MinimumNArgs(1),
 	PreRun: func(_ *cobra.Command, _ []string) {
 		// set the verbosity of the logger(s)
@@ -47,8 +47,10 @@ func init() {
 	rootCmd.Flags().BoolVarP(&parse.Flags.Link, "link", "l", false, "show the verses referenced in footnotes of selected verse(s)")
 	rootCmd.Flags().BoolVarP(&parse.Flags.Headings, "headings", "H", false, "Show headings for selected chapter(s)")
 	rootCmd.Flags().BoolVar(&parse.Flags.HeadingsOnly, "headings-only", false, "Show only the headings for selected chapter(s)")
-	rootCmd.Flags().BoolVarP(&parse.Flags.Refs, "refs", "r", false, "show full refereces with each verse displayed")
+	rootCmd.Flags().BoolVarP(&parse.Flags.Refs, "refs", "r", false, "hide chapter and verse references with each verse displayed")
+	rootCmd.Flags().BoolVarP(&parse.Flags.RefsFull, "refs-full", "R", false, "show full references (book and chapter) with each verse displayed")
 	rootCmd.Flags().BoolVarP(&parse.Flags.Paragraphs, "pars", "p", false, "print text in paragraphs")
+	rootCmd.Flags().StringVarP(&parse.Flags.Language, "lang", "L", "eng", "language to display in")
 }
 
 // run parses the references from the arguments and sends them for retreival and display

--- a/internal/parse/abbrev.go
+++ b/internal/parse/abbrev.go
@@ -7,39 +7,38 @@ package parse
 import "strings"
 
 var abbrevMap = map[string]string{
-	"OLD TESTAMENT": "[OT]", "Genesis": "gen", "Exodous": "ex", "Leviticus": "lev", "Deuteronomy": "deut",
-	"Numbers": "num", "Joshua": "jos", "Judges": "judg", "Ruth": "ruth", "1 Samuel": "1-sam",
-	"2 Samuel": "2-sam", "1 Kings": "1-kin", "2 Kings": "2-kin", "1 Chronicles": "1-chr",
-	"2 Chronicles": "2-chr", "Ezra": "ezra", "Nehemiah": "neh", "Esther": "esth", "Job": "job",
-	"Psalms": "ps", "Proverbs": "prov", "Ecclesiastes": "eccl", "Song of Solomon": "song", "Isaiah": "isa",
-	"Jeremiah": "jer", "Lamentations": "lam", "Ezekiel": "ezek", "Daniel": "dan", "Hosea": "hosea",
-	"Joel": "joel", "Amos": "amos", "Obadiah": "obad", "Jonah": "jonah", "Micah": "micah", "Nahum": "nahum",
-	"Habakkuk": "hab", "Zephaniah": "zeph", "Haggai": "hag", "Zechariah": "zech", "Malachi": "mal",
-	"NEW TESTAMENT": "[NT]", "Matthew": "matt", "Mark": "mark", "Luke": "luke", "John": "john",
-	"Acts": "acts", "Romans": "rom", "1 Corinthians": "1-cor", "2 Corinthians": "2-cor", "Galations": "gal",
-	"Ephesians": "eph", "Philippians": "philip", "Colossians": "col", "1 Thessalonians": "1-thes",
-	"2 Thessalonians": "2-thes", "1 Timothy": "1-tim", "2 Timothy": "2-tim", "Titus": "titus",
-	"Philemon": "philem", "Hebrews": "heb", "James": "jas", "1 Peter": "1-pet", "2 Peter": "2-pet",
-	"1 John": "1-jn", "2 John": "2-jn", "3 John": "3-jn", "Jude": "jude", "Revelation": "rev",
+	"old testament": "[ot]", "genesis": "gen", "exodous": "ex", "leviticus": "lev", "deuteronomy": "deut",
+	"numbers": "num", "joshua": "josh", "judges": "judg", "1 samuel": "1-sam",
+	"2 samuel": "2-sam", "1 kings": "1-kin", "2 kings": "2-kin", "1 chronicles": "1-chr",
+	"2 chronicles": "2-chr", "nehemiah": "neh", "esther": "esth",
+	"psalms": "ps", "proverbs": "prov", "ecclesiastes": "eccl", "song of solomon": "song", "ss": "song", "isaiah": "isa",
+	"jeremiah": "jer", "lamentations": "lam", "ezekiel": "ezek", "daniel": "dan", "obadiah": "obad",
+	"habakkuk": "hab", "zephaniah": "zeph", "haggai": "hag", "zechariah": "zech", "malachi": "mal",
+	"new testament": "[nt]", "matthew": "matt",
+	"romans": "rom", "1 corinthians": "1-cor", "2 corinthians": "2-cor", "galations": "gal",
+	"ephesians": "eph", "philippians": "philip", "colossians": "col", "1 thessalonians": "1-thes",
+	"2 thessalonians": "2-thes", "1 timothy": "1-tim", "2 timothy": "2-tim",
+	"philemon": "philem", "hebrews": "heb", "1 peter": "1-pet", "2 peter": "2-pet",
+	"1 john": "1-jn", "2 john": "2-jn", "3 john": "3-jn", "revelation": "rev",
 
-	"BOOK OF MORMON": "[BOM]", "1 Nephi": "1-ne", "2 Nephi": "2-ne", "Jacob": "jacob", "Enos": "enos",
-	"Jarom": "jarom", "Omni": "omni", "Words of Mormon": "w-of-m", "Mosiah": "mosiah", "Alma": "alma",
-	"Helaman": "hel", "3 Nephi": "3-ne", "4 Nephi": "4-ne", "Mormon": "morm", "Ether": "ether",
-	"Moroni": "moro",
+	"book of mormon": "[bom]", "1 nephi": "1-ne", "2 nephi": "2-ne", "words of mormon": "w-of-m",
+	"helaman": "hel", "3 nephi": "3-ne", "4 nephi": "4-ne", "mormon": "morm",
+	"moroni": "moro",
 
-	"DOCTRINE AND COVENANTS": "[DC]", "Sections": "dc",
+	"doctrine and covenants": "[dc]", "sections": "dc",
 
-	"PEARL OF GREAT PRICE": "[PGP]", "Moses": "moses", "Abraham": "abr", "JS-Matthew": "js-m", "JS-History": "js-h",
-	"Articles of Faith": "a-of-f", "Epistle Dedicatory": "dedication", "BofM Title Page": "bofm-title",
-	"Title Page of the Book of Mormon": "title-page", "Introduction": "introduction",
-	"Testimony of the Three Witnesses": "three", "Testimony of the Eight Witnesses": "eight",
-	"Testimony of the ProphetJoseph Smith": "js", "A Brief Explanation of the BofM": "explanation",
-	"Official Declarations": "od",
+	"pearl of great price": "[pgp]", "abraham": "abr", "js-matthew": "js-m", "js-history": "js-h",
+	"articles of faith": "a-of-f", "epistle dedicatory": "dedication", "bofm title page": "bofm-title",
+	"title page of the book of mormon": "title-page", "introduction": "introduction",
+	"testimony of the three witnesses": "three", "testimony of the eight witnesses": "eight",
+	"testimony of the prophet joseph smith": "js", "a brief explanation of the bofm": "explanation",
+	"official declarations": "od",
 }
 
 // PutAbbrevs replaces instances full book names with the supported abbreviated counterparts
 func PutAbbrevs(in string) string {
 	for long, abbrev := range abbrevMap {
+		in = strings.ToLower(in)
 		in = strings.Replace(in, long, abbrev, -1)
 	}
 	return in

--- a/internal/parse/reference.go
+++ b/internal/parse/reference.go
@@ -10,11 +10,13 @@ import (
 type flags struct {
 	Context      int // not yet implemented
 	Footnotes    bool
-	JST          bool // not yet implemented
-	Link         bool // not yet implemented
+	JST          bool   // not yet implemented
+	Language     string // not yet implemented
+	Link         bool   // not yet implemented
 	Headings     bool
 	HeadingsOnly bool
 	Refs         bool
+	RefsFull     bool // not yet implemented
 	Paragraphs   bool // not yet implemented
 }
 
@@ -30,7 +32,7 @@ type Lookuper interface {
 	Lookup(flags) error
 }
 
-// makeRanve takes two numbers (as strings) and creates a range of ints-in-strings
+// makeRange takes two numbers (as strings) and creates a range of ints-in-strings
 // from the lower to the upper (if it's actually lower)
 func makeRange(lower, upper string) ([]string, error) {
 	var list []string
@@ -85,12 +87,22 @@ func (r *ReferenceVerses) Lookup(f flags) error {
 	}
 
 	for _, vs := range r.Verse {
+
+		// if it's empty, then just say an error
 		if chap.Verses[vs].Text == "" {
 			fmt.Printf("Failed: Chapter %s has no verse %s\n", r.Chapter, vs)
 		}
-		if f.Refs {
+
+		// handle the references
+		if f.RefsFull {
+			// RefsFull prints the book and chapter for the
+			fmt.Printf(" [%s %s:%s]", r.Book, r.Chapter, vs)
+		} else if f.Refs {
+			// Refs means print the verse number before the verse
 			fmt.Printf(" %s", vs)
 		}
+
+		// should we put the footnotes in?
 		if f.Footnotes {
 			fmt.Printf(" %s\n", chap.Verses[vs].putFootnotes())
 			fmt.Printf("    %s\n", chap.Verses[vs].formatFootnotes())
@@ -98,9 +110,6 @@ func (r *ReferenceVerses) Lookup(f flags) error {
 			fmt.Printf(" %s\n", chap.Verses[vs].Text)
 		}
 	}
-
-	// print an extra newline for good measure
-	fmt.Print("\n")
 
 	return nil
 }
@@ -142,9 +151,17 @@ func (r *ReferenceChapters) Lookup(f flags) error {
 		// print the text of the chapter
 		for i := 1; i <= len(chap.Verses); i++ {
 			verse := chap.Verses[strconv.Itoa(i)]
-			if f.Refs {
+
+			// handle references
+			if f.RefsFull {
+				// RefsFull prints the book and chapter for the
+				fmt.Printf(" [%s %s:%d]", r.Book, lookupChap, i)
+			} else if f.Refs {
+				// Refs means print the verse numbers
 				fmt.Printf(" %d", i)
 			}
+
+			// should we put the footnotes?
 			if f.Footnotes {
 				fmt.Printf(" %s\n", verse.putFootnotes())
 				fmt.Printf("    %s\n\n", verse.formatFootnotes())


### PR DESCRIPTION
:tada: Finished v0.1.1 :tada:

New features:
 * The `--refs-full` (`-R`) option now works to display the whole reference
    * I find this useful for printing whole chapters or sections and grepping them for a particular verse
 * Lowercase full names now work for book names

Bugfixes:
 * Changed some abbreviations that were wrong