### PR TITLE
Es3649/enh/wildcard

### DIFF
--- a/internal/parse/analyzer.go
+++ b/internal/parse/analyzer.go
@@ -61,7 +61,7 @@ func (a *analyzer) analyze() (err error) {
 	for _, curString := range a.toParse {
 		// no length 0 strings!
 		if curString == "" {
-			fmt.Print("Got empty arg")
+			fmt.Println("Got empty arg")
 			continue
 		}
 		log.WithFields(logrus.Fields{"where": "analyze", "arg": curString}).Info("Analyzing argument")

--- a/internal/parse/expand.go
+++ b/internal/parse/expand.go
@@ -1,0 +1,48 @@
+package parse
+
+import (
+	"fmt"
+	"strings"
+)
+
+// TODO this only works with one set of braces, redo it with graph theory
+// and recursion
+// {matt|    {1|
+// |mark| 1: |2| ;
+// |luke}    |3}
+func expandBraces(s string) (string, error) {
+	log.WithField("value", s).Info("Expanding the argument")
+	i := strings.Index(s, "{")
+	j := strings.Index(s, "}")
+	// for each ocurrence of '{' and '}', expand them
+	for i >= 0 && j >= 0 {
+		// make sure there is no mismatch, if one of them exists,
+		// we need to have the other to match with it
+		if (i == -1) != (j == -1) {
+			return "", fmt.Errorf("Mismatched braces: '{' at pos %d and '}' at pos %d", i, j)
+		}
+		// slice the string at the given indicies and expand it
+		prefix := s[:i]
+		suffix := s[j+1:]
+		pieces := strings.Split(s[i+1:j], ",")
+		s = ""
+		for _, piece := range pieces {
+			log.WithField("value", piece).Debug("Building with piece")
+			s += prefix + piece + suffix + ";"
+		}
+		// reset the conditions to be sure we're good
+		i = strings.Index(s, "{")
+		j = strings.Index(s, "}")
+		log.WithField("value", s).Debug("completed an expansion")
+	}
+	log.WithField("value", s).Info("Expanded the argument")
+	return s, nil
+}
+
+// expandTomeClasses will expand references with tome wildcards in them, such as
+// [ot], [nt], [bofm], [dc], [pgp]
+// TODO decide on good functionality for this function
+// Should we call it on unprocessed args, or on Lookupers?
+func expandTomeClasses(s string) (string, error) {
+	return s, nil
+}

--- a/internal/parse/parse.go
+++ b/internal/parse/parse.go
@@ -2,7 +2,6 @@ package parse
 
 import (
 	"fmt"
-	"strings"
 	"sync"
 
 	"github.com/sirupsen/logrus"
@@ -10,45 +9,11 @@ import (
 
 var refs []Lookuper
 
-// TODO this only works with one set of braces, redo it with graph theory
-// and recursion
-// [matt     [1
-//  mark  1:  2  ;
-//  luke]     3]
-func expand(s string) (string, error) {
-	log.WithField("value", s).Info("Expanding the argument")
-	i := strings.Index(s, "{")
-	j := strings.Index(s, "}")
-	// for each ocurrence of '{' and '}', expand them
-	for i >= 0 && j >= 0 {
-		// make sure there is no mismatch, if one of them exists,
-		// we need to have the other to match with it
-		if (i == -1) != (j == -1) {
-			return "", fmt.Errorf("Mismatched braces: '{' at pos %d and '}' at pos %d", i, j)
-		}
-		// slice the string at the given indicies and expand it
-		prefix := s[:i]
-		suffix := s[j+1:]
-		pieces := strings.Split(s[i+1:j], ",")
-		s = ""
-		for _, piece := range pieces {
-			log.WithField("value", piece).Debug("Building with piece")
-			s += prefix + piece + suffix + ";"
-		}
-		// reset the conditions to be sure we're good
-		i = strings.Index(s, "{")
-		j = strings.Index(s, "}")
-		log.WithField("value", s).Debug("completed an expansion")
-	}
-	log.WithField("value", s).Info("Expanded the argument")
-	return s, nil
-}
-
 // Parse parses the command line arguments then TODO
 func Parse(args []string) (err error) {
 	// expand the args
 	for i := range args {
-		args[i], err = expand(args[i])
+		args[i], err = expandBraces(args[i])
 		if err != nil {
 			return err
 		}

--- a/internal/parse/parser.go
+++ b/internal/parse/parser.go
@@ -98,8 +98,10 @@ func (p *parser) parseOrder() error {
 			case aNumberState:
 				p.curState = pChapNum
 				p.curChap = tok.Value
-			// case aSemicolonState:
-			// 	p.curState = pStartState
+			case aSemicolonState:
+				curBook := ReferenceBook(p.curBook)
+				p.Results = append(p.Results, &curBook)
+				p.curState = pStartState
 			default:
 				return fmt.Errorf("Invalid token received: %#v", tok)
 			}
@@ -230,7 +232,7 @@ func (p *parser) parseOrder() error {
 			}
 
 			/////////////
-			// TODO all this below: the verse numbers don't get saved into Lookupers yet
+			// TODO all this below: the verse numbers don't get saved into Lookupers yet on multiple iterations
 			/////////////
 		case pVerseNum:
 			switch tok.Type {

--- a/internal/scriptures/scriptures.go
+++ b/internal/scriptures/scriptures.go
@@ -5,7 +5,10 @@ package scriptures
 type Tome []string
 
 // OldTestament is a tome with the books of the Old Testament
-var OldTestament = Tome([]string{"gen"})
+var OldTestament = Tome([]string{"gen", "ex", "lev", "deut", "num", "josh", "judg", "ruth",
+	"1-sam", "2-sam", "1-kgs", "2-kgs", "1-chr", "2-chr", "ezra", "neh", "esth", "job", "ps",
+	"prov", "eccl", "song", "isa", "jer", "lam", "ezek", "dan", "hosea", "joel", "amos", "obad",
+	"jonah", "micah", "nahum", "hab", "zeph", "hag", "zech", "mal"})
 
 // NewTestament is a tome with the books of the New Testament
 var NewTestament = Tome([]string{"matt", "mark", "luke", "john", "acts", "rom", "1-cor", "2-cor",

--- a/internal/scriptures/scriptures.go
+++ b/internal/scriptures/scriptures.go
@@ -1,0 +1,24 @@
+package scriptures
+
+// Tome is an alias for []string
+// it holds a list of books withing a tome
+type Tome []string
+
+// OldTestament is a tome with the books of the Old Testament
+var OldTestament = Tome([]string{"gen"})
+
+// NewTestament is a tome with the books of the New Testament
+var NewTestament = Tome([]string{"matt", "mark", "luke", "john", "acts", "rom", "1-cor", "2-cor",
+	"gal", "eph", "philip", "col", "1-thes", "2-thes", "1-tim", "2-tim",
+	"titus", "philem", "heb", "james", "1-pet", "2-pet", "1-jn", "2-jn",
+	"3-jn", "jude", "rev"})
+
+// BookOfMormon is a tome with the books of the Book of Mormon
+var BookOfMormon = Tome([]string{"1-ne", "2-ne", "jacob", "enos", "jarom", "omni", "w-of-m",
+	"mosiah", "alma", "hel", "3-ne", "4-ne", "morm", "ether", "moro"})
+
+// DoctrineAndCovenants is a tome with the book of the Doctrin and Covenants
+var DoctrineAndCovenants = Tome([]string{"dc"})
+
+// PearlOfGreatPrice is a tome with the books of the Pearl Of Great Price
+var PearlOfGreatPrice = Tome([]string{"mos", "abr", "js-h", "js-m", "a-of-f"})


### PR DESCRIPTION
:tada: v0.1.3 :tada: 

Now you can look up whole booksand entire "tomes"
Use the [ot], [nt], [bofm], [dc], [pgp] tokens to print out entire books of scripture,
or [all] to print out all scripture.

This is nice to pipe into `grep` for good searching. Be sure to use the `-R` flag
to see the complete reference associated with the search results.