### PR TITLE
added better referencing for headings

### DIFF
--- a/internal/lookup/reference.go
+++ b/internal/lookup/reference.go
@@ -129,7 +129,12 @@ func lookupChapterFromPath(book, chapnum, path string) error {
 	}
 
 	if Flags.Headings || Flags.HeadingsOnly {
-		fmt.Println(chap.Heading)
+		if Flags.RefsFull {
+			fmt.Printf(" [%s %s:H]", book, chapnum)
+		} else if Flags.Refs && !Flags.HeadingsOnly {
+			fmt.Print(" H")
+		}
+		fmt.Printf(" %s\n", chap.Heading)
 	}
 
 	// if we only wanted the headings...


### PR DESCRIPTION
Headings now have their own references:
* Headings not shown by default when looking up whole chapters, or sets of chapters
* `H` is the "verse number" for headings
  * This "verse number" is still omitted with `-r`
* Add full length references to headings (with `-R` flag)

addresses #10