### PR TITLE
Es3649/enh/grammar fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ This content is publicly available on lds.org/scriptures, and I personally invit
 
 ## Status:
  * Parses correctly formatted references
+    * Looks up entire books or entire tomes
+ * Default pages to `less`
+    * Reverts to stdout with the `-o` flag
  * Library compiles
     * lib-download.sh works but takes HOURS to run, fix this
        * multithreading?
@@ -27,11 +30,7 @@ This content is publicly available on lds.org/scriptures, and I personally invit
  * Add boundaries on the verses.
     * No chapter greater than 150 (Psalms)
     * No verse greater than 176 (Ps 119) 
- * Panics when putting footnotes if there are none
  * Implement all cmd line flags
- * Multiple args doesn't work
  * Implement the cool features
-    * Tome classes
     * Brace expansion {Matt,Mark,Luke}
     * Use of wildcard (*)
-    * Semicolon stuff (reevaluate grammar)

--- a/compare.sh
+++ b/compare.sh
@@ -5,7 +5,7 @@ if [[ "$1" == "" || "$2" == "" ]]; then
     exit 1
 fi
 
-./scripturetool $1 | tr " " "\n" > $1.txt
-./scripturetool $2 | tr " " "\n" > $2.txt
+./scripturetool -o $1 | tr " " "\n" > $1.txt
+./scripturetool -o $2 | tr " " "\n" > $2.txt
 diff -y $1.txt $2.txt | less
 rm $1.txt $2.txt

--- a/internal/parse/analyzer.go
+++ b/internal/parse/analyzer.go
@@ -9,18 +9,19 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-type analyzerState int
+type analyzerState rune
 
 const (
-	aStartState     analyzerState = 0
-	aSemicolonState analyzerState = 1
-	aColonState     analyzerState = 2
-	aCommaState     analyzerState = 3
-	aDashState      analyzerState = 4
-	aNumberState    analyzerState = 5
-	aBookState      analyzerState = 6
-	aUndefinedState analyzerState = 7
-	aStarState      analyzerState = 8
+	aStartState      analyzerState = 0
+	aSemicolonState  analyzerState = 1
+	aColonState      analyzerState = 2
+	aCommaState      analyzerState = 3
+	aDashState       analyzerState = 4
+	aNumberState     analyzerState = 5
+	aBookState       analyzerState = 6
+	aUndefinedState  analyzerState = 7
+	aStarState       analyzerState = 8
+	aCurlyBraceState analyzerState = 9
 )
 
 type token struct {
@@ -120,15 +121,17 @@ func (a *analyzer) finish() error {
 	case aNumberState:
 		a.makeToken(aNumberState)
 		// fmt.Print("finish analysis-number state\n")
-		return nil
 	case aBookState:
 		// fmt.Print("finish analysis-book state\n")
 		a.makeToken(aBookState)
-		return nil
+	case aStarState:
+		a.makeToken(aStarState)
 	default:
 		// fmt.Print("finish analysis-bad state\n")
 		return fmt.Errorf("Invalid end of string: %s", a.value)
 	}
+	a.makeToken(aSemicolonState)
+	return nil
 }
 
 func (a *analyzer) semicolon(c rune) {

--- a/internal/parse/doc.go
+++ b/internal/parse/doc.go
@@ -21,21 +21,18 @@
 // be given as one argument. The grammar should also be recorded somewhere,
 // here is probably as good as anywhere.
 //
-// TODO add bash-style curly brace lists
-// add wildcards
-// consider adding tomes
-// <start>			::= <reference> <referencelist>
-// <referencelist> 	::= ;<reference> <refrencelist> | ; | <lambda>
-// <reference> 		::= <book> | <book> <chapter> <chapterlist> | <book> <chapter> : <verse> <verselist>
-// <book>			::= <string>
-// <string>			::= [::alnum::[]-] <string> | <\lambda>
-// <lambda> 		::=
+// <start>			::= <reference> <referencelist> ';'?
+// <referencelist> 	::= ';' <reference> <refrencelist> | ';' | <lambda>
+// <reference> 		::= <book> | <book> (<chapter> <chapterlist> | '*') | <book> (<chapter> | '*') ':' (<verse> <verselist> | '*')
+// <book>			::= [::alnum::[]] <string> | '*'
+// <string>			::= []-::alpha::] <string> | <lambda>
+// <lambda> 		::= ''
 // <integer>		::= [0-9] <integer> | <lambda>
 // <chapter>		::= <integer> | <integerrange>
-// <chapterlist>	::= , <chapter> <chapterlist> | <lambda>
-// <integerrange>	::= <integer> - <integer>
+// <chapterlist>	::= ',' <chapter> <chapterlist> | <lambda>
+// <integerrange>	::= <integer> '-' <integer>
 // <verse>			::= <integer> | <integerrange>
-// <verselist>		::= , <verse> <verserange> | <lambda>
+// <verselist>		::= ',' <verse> <verselist> | <lambda>
 //
 // It would also be good to fix the multithreading. As it was it would
 // deadlock whenever there was a parse error.

--- a/internal/parse/parse.go
+++ b/internal/parse/parse.go
@@ -70,6 +70,7 @@ func displayAll(refs []lookup.Lookuper) {
 
 	// lookup all the references we got from the parser
 	for _, reference := range refs {
+		log.Log.WithFields(logrus.Fields{"where": "displayAll", "reference": fmt.Sprintf("%#v", reference)}).Info("Looking up Refrence")
 		if err := reference.Lookup(lookup.Flags); err != nil {
 			fmt.Printf("Error looking up the given reference: %#v\n", reference)
 			fmt.Printf("  Error is: %v\n", err)


### PR DESCRIPTION
Grammar works now for multiple arguments.

They parse correctly (including wildcards, soon to be implemented)
It actually looks them both up

Addresses #6 and #9